### PR TITLE
Change syntax for specifying dependency, lock to 19.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
 <!--
 		<dependency id="com.google.playservices" url="https://github.com/MobileChromeApps/google-play-services" commit="5d784fb083027fd2c1ef1545d8a2b0d595e4ec69" />
 -->		
-		<dependency id="com.google.playservices@17.0.0" />
+		<dependency id="com.google.playservices@19.0.0" />
 		
 	    <config-file target="res/xml/config.xml" parent="/*">
             <feature name="Admob" >


### PR DESCRIPTION
Looks like version= is ignored but @19.0.0 can lock to a specific version. XDK needs to upgrade its android build tools before you can use the latest version (21) of this plugin. 
